### PR TITLE
bug/TYTA-118/use-navigate-hook-instead-of-link-component-404-back-home-button

### DIFF
--- a/src/pages/Forbidden/Forbidden.jsx
+++ b/src/pages/Forbidden/Forbidden.jsx
@@ -1,42 +1,47 @@
 import './Forbidden.scss';
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Container, Typography, Box, Button } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 import ForbiddenImg from '../../assets/forbidden.svg';
 
-const Forbidden = () => (
-  <Container
-    sx={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: 10,
-      my: 10,
-    }}
-  >
-    <Box
-      component="img"
+const Forbidden = () => {
+  const navigate = useNavigate();
+  return (
+    <Container
       sx={{
-        width: '50%',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        my: 10,
       }}
-      alt="Lock page."
-      src={ForbiddenImg}
-    />
-    <Box>
-      <Typography variant="h3">Oups...</Typography>
-      <Typography variant="h5">Not authorized</Typography>
-      <Typography variant="body1" sx={{ my: 2, mb: 5 }}>
-        You need to be connected, or you don't have access to this page
-      </Typography>
-      <Link to="/">
-        <Button variant="contained" startIcon={<ArrowBackIcon />}>
+    >
+      <Box
+        component="img"
+        sx={{
+          width: '50%',
+        }}
+        alt="Lock page."
+        src={ForbiddenImg}
+      />
+      <Box>
+        <Typography variant="h3">Oups...</Typography>
+        <Typography variant="h5">Not authorized</Typography>
+        <Typography variant="body1" sx={{ my: 2, mb: 5 }}>
+          You need to be connected, or you don't have access to this page
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<ArrowBackIcon />}
+          onClick={() => navigate('/')}
+        >
           Back to home
         </Button>
-      </Link>
-    </Box>
-  </Container>
-);
+      </Box>
+    </Container>
+  );
+};
 
 export default Forbidden;

--- a/src/pages/NotFound/NotFound.jsx
+++ b/src/pages/NotFound/NotFound.jsx
@@ -1,40 +1,48 @@
 import './NotFound.scss';
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Container, Typography, Box, Button } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 import NotFoundImg from '../../assets/not-found.svg';
 
-const NotFound = () => (
-  <Container
-    sx={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: 10,
-      my: 10,
-    }}
-  >
-    <Box
-      component="img"
+const NotFound = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Container
       sx={{
-        width: '60%',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        my: 10,
       }}
-      alt="The house from the offer."
-      src={NotFoundImg}
-    />
-    <Box>
-      <Typography variant="h3">Oups...</Typography>
-      <Typography variant="h5">Page not foud</Typography>
-      <Typography variant="body1" sx={{ my: 2, mb: 5 }}>
-        It seems that this page does not exist or no longer exists
-      </Typography>
-      <Button variant="contained" startIcon={<ArrowBackIcon />}>
-        <Link to="/">Back to home</Link>
-      </Button>
-    </Box>
-  </Container>
-);
+    >
+      <Box
+        component="img"
+        sx={{
+          width: '60%',
+        }}
+        alt="The house from the offer."
+        src={NotFoundImg}
+      />
+      <Box>
+        <Typography variant="h3">Oups...</Typography>
+        <Typography variant="h5">Page not foud</Typography>
+        <Typography variant="body1" sx={{ my: 2, mb: 5 }}>
+          It seems that this page does not exist or no longer exists
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<ArrowBackIcon />}
+          onClick={() => navigate('/')}
+        >
+          Back to home
+        </Button>
+      </Box>
+    </Container>
+  );
+};
 
 export default NotFound;


### PR DESCRIPTION
### Description

Fix bug on `Back to home` button when we click behind the text and we are not redirected